### PR TITLE
Update conda install to use an environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ although newer versions should also work, using the same version (as specified b
 If using conda, create a conda environment with the requisite versions:
 
 ```shell
-conda create -n maptext-eval python=3.9.18 --file conda-requirements.txt
+conda env create -f conda-environment.yaml
 conda activate maptext-eval
-pip install -r pip-requirements.txt
 ```
 
 ### Pipenv Installation

--- a/conda-environment.yaml
+++ b/conda-environment.yaml
@@ -1,0 +1,12 @@
+name: maptext-eval
+channels:
+  - defaults
+dependencies:
+  - numpy==1.26.2
+  - python=3.9.18
+  - shapely==2.0.1
+  - scipy==1.11.4
+  - pip=23.3.1
+  - pip:
+      - polygon3==3.0.9.1
+      - pyeditdistance==1.0.1

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,3 +1,0 @@
-numpy==1.26.2
-shapely==2.0.1
-scipy==1.11.4

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,1 +1,0 @@
-pyeditdistance==1.0.1


### PR DESCRIPTION
Simplifies installation by including pip requirements rather than requiring a secondary install command